### PR TITLE
Puppet 4 does not consider empty string boolean false

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -193,7 +193,7 @@ class solr (
   }
 
   # Whole solr configuration directory can be recursively overriden
-  if $solr::source_dir {
+  if $solr::source_dir and $solr::source_dir != '' {
     file { 'solr.dir':
       ensure  => directory,
       path    => $solr::config_dir,


### PR DESCRIPTION
> Error: Parameter source failed on File[solr.dir]: Cannot use relative URLs '' at /tmp/vagrant-puppet/modules/solr/manifests/init.pp:197

Due to Puppet 4.x considering the following statement as true:

```
$source_dir = ''
if $source_dir {}
```
